### PR TITLE
Change information concerning password-hashing

### DIFF
--- a/Configuration.md
+++ b/Configuration.md
@@ -152,6 +152,7 @@ You can adapt HORNET to your needs. The configuration options are shown below.
     ```json
     ""
     ```
+    See pwdhash-Tool for encoding: [pwdhash](./Tools#Password HEX-Encoded string generator)
 - `dashboard.basicAuth.passwordsalt` string
   - The HTTP basic auth salt used for hashing the password (must be lower cased)
     <br>Default:
@@ -234,6 +235,7 @@ You can adapt HORNET to your needs. The configuration options are shown below.
     ```json
     ""
     ```
+    See pwdhash-Tool for encoding: [pwdhash](./Tools#Password HEX-Encoded string generator)
 - `httpAPI.basicauth.passwordsalt` string
   - The HTTP basic auth salt used for hashing the password (must be lower cased)
     <br>Default:

--- a/Configuration.md
+++ b/Configuration.md
@@ -152,7 +152,7 @@ You can adapt HORNET to your needs. The configuration options are shown below.
     ```json
     ""
     ```
-    See pwdhash-Tool for encoding: [pwdhash](http://github.com/gohornet/wiki/Tools.md)
+    See pwdhash-Tool for encoding: [pwdhash](https://github.com/gohornet/wiki/Tools.md)
 - `dashboard.basicAuth.passwordsalt` string
   - The HTTP basic auth salt used for hashing the password (must be lower cased)
     <br>Default:

--- a/Configuration.md
+++ b/Configuration.md
@@ -152,7 +152,7 @@ You can adapt HORNET to your needs. The configuration options are shown below.
     ```json
     ""
     ```
-    See pwdhash-Tool for encoding: [pwdhash](https://github.com/gohornet/wiki/Tools.md)
+    See pwdhash-Tool for encoding: [pwdhash](https://github.com/gohornet/wiki/Tools)
 - `dashboard.basicAuth.passwordsalt` string
   - The HTTP basic auth salt used for hashing the password (must be lower cased)
     <br>Default:
@@ -235,7 +235,7 @@ You can adapt HORNET to your needs. The configuration options are shown below.
     ```json
     ""
     ```
-    See pwdhash-Tool for encoding: [pwdhash](http://github.com/gohornet/wiki/Tools.md%3A-Password-HEX-Encoded-string-generator)
+    See pwdhash-Tool for encoding: [pwdhash](https://github.com/gohornet/wiki/Tools%3A-Password-HEX-Encoded-string-generator)
 - `httpAPI.basicauth.passwordsalt` string
   - The HTTP basic auth salt used for hashing the password (must be lower cased)
     <br>Default:

--- a/Configuration.md
+++ b/Configuration.md
@@ -152,7 +152,8 @@ You can adapt HORNET to your needs. The configuration options are shown below.
     ```json
     ""
     ```
-    See pwdhash-Tool for encoding: [pwdhash](https://github.com/gohornet/wiki/Tools)
+    See Encoding-Tool (pwdhash) on Tools-page for more information.
+    
 - `dashboard.basicAuth.passwordsalt` string
   - The HTTP basic auth salt used for hashing the password (must be lower cased)
     <br>Default:
@@ -235,7 +236,8 @@ You can adapt HORNET to your needs. The configuration options are shown below.
     ```json
     ""
     ```
-    See pwdhash-Tool for encoding: [pwdhash](https://github.com/gohornet/wiki/Tools%3A-Password-HEX-Encoded-string-generator)
+    See Encoding-Tool (pwdhash) on Tools-page for more information.
+    
 - `httpAPI.basicauth.passwordsalt` string
   - The HTTP basic auth salt used for hashing the password (must be lower cased)
     <br>Default:

--- a/Configuration.md
+++ b/Configuration.md
@@ -152,7 +152,7 @@ You can adapt HORNET to your needs. The configuration options are shown below.
     ```json
     ""
     ```
-    See pwdhash-Tool for encoding: [pwdhash](./Tools#Password HEX-Encoded string generator)
+    See pwdhash-Tool for encoding: [pwdhash](./Tools%3A-Password-HEX-Encoded-string-generator)
 - `dashboard.basicAuth.passwordsalt` string
   - The HTTP basic auth salt used for hashing the password (must be lower cased)
     <br>Default:
@@ -235,7 +235,7 @@ You can adapt HORNET to your needs. The configuration options are shown below.
     ```json
     ""
     ```
-    See pwdhash-Tool for encoding: [pwdhash](./Tools#Password HEX-Encoded string generator)
+    See pwdhash-Tool for encoding: [pwdhash](./Tools%3A-Password-HEX-Encoded-string-generator)
 - `httpAPI.basicauth.passwordsalt` string
   - The HTTP basic auth salt used for hashing the password (must be lower cased)
     <br>Default:

--- a/Configuration.md
+++ b/Configuration.md
@@ -152,7 +152,7 @@ You can adapt HORNET to your needs. The configuration options are shown below.
     ```json
     ""
     ```
-    See pwdhash-Tool for encoding: [pwdhash](./Tools)
+    See pwdhash-Tool for encoding: [pwdhash](http://github.com/gohornet/wiki/Tools.md)
 - `dashboard.basicAuth.passwordsalt` string
   - The HTTP basic auth salt used for hashing the password (must be lower cased)
     <br>Default:
@@ -235,7 +235,7 @@ You can adapt HORNET to your needs. The configuration options are shown below.
     ```json
     ""
     ```
-    See pwdhash-Tool for encoding: [pwdhash](./Tools%3A-Password-HEX-Encoded-string-generator)
+    See pwdhash-Tool for encoding: [pwdhash](http://github.com/gohornet/wiki/Tools.md%3A-Password-HEX-Encoded-string-generator)
 - `httpAPI.basicauth.passwordsalt` string
   - The HTTP basic auth salt used for hashing the password (must be lower cased)
     <br>Default:

--- a/Configuration.md
+++ b/Configuration.md
@@ -152,7 +152,7 @@ You can adapt HORNET to your needs. The configuration options are shown below.
     ```json
     ""
     ```
-    See Encoding-Tool (pwdhash) on Tools-page for more information.
+    See Encoding-Tool (pwdhash) on [Tools-Page](https://github.com/gohornet/hornet/wiki/Tools) for more information.
     
 - `dashboard.basicAuth.passwordsalt` string
   - The HTTP basic auth salt used for hashing the password (must be lower cased)
@@ -236,7 +236,7 @@ You can adapt HORNET to your needs. The configuration options are shown below.
     ```json
     ""
     ```
-    See Encoding-Tool (pwdhash) on Tools-page for more information.
+    See Encoding-Tool (pwdhash) on [Tools-Page](https://github.com/gohornet/hornet/wiki/Tools) for more information.
     
 - `httpAPI.basicauth.passwordsalt` string
   - The HTTP basic auth salt used for hashing the password (must be lower cased)

--- a/Configuration.md
+++ b/Configuration.md
@@ -147,7 +147,7 @@ You can adapt HORNET to your needs. The configuration options are shown below.
     ""
     ```
 - `dashboard.basicAuth.passwordhash` string
-  - The HTTP basic auth password+salt as a sha256 hash (must be lower cased)
+  - The HTTP basic auth password+salt as a HEX-Encoded string (must be lower cased)
     <br>Default:
     ```json
     ""
@@ -229,7 +229,7 @@ You can adapt HORNET to your needs. The configuration options are shown below.
     ""
     ```
 - `httpAPI.basicauth.passwordhash` string
-  - The HTTP basic auth password+salt as a sha256 hash (must be lower cased)
+  - The HTTP basic auth password+salt as a HEX-Encoded string (must be lower cased)
     <br>Default:
     ```json
     ""

--- a/Configuration.md
+++ b/Configuration.md
@@ -152,7 +152,7 @@ You can adapt HORNET to your needs. The configuration options are shown below.
     ```json
     ""
     ```
-    See pwdhash-Tool for encoding: [pwdhash](./Tools%3A-Password-HEX-Encoded-string-generator)
+    See pwdhash-Tool for encoding: [pwdhash](./Tools)
 - `dashboard.basicAuth.passwordsalt` string
   - The HTTP basic auth salt used for hashing the password (must be lower cased)
     <br>Default:

--- a/Tools.md
+++ b/Tools.md
@@ -9,9 +9,9 @@ Generates an autopeering seed.<br>
 hornet tool seedgen
 ```
 
-### Password SHA256 sum generator
+### Password HEX-encoded string generator
 
-Generates an sha265 sum from your password and salt.
+Generates an HEX-encoded string from your password and salt.
 
 ```bash
 hornet tool pwdhash

--- a/Tools.md
+++ b/Tools.md
@@ -9,9 +9,9 @@ Generates an autopeering seed.<br>
 hornet tool seedgen
 ```
 
-### Password HEX-encoded string generator
+### Password HEX-Encoded string generator
 
-Generates an HEX-encoded string from your password and salt.
+Generates an HEX-Encoded string from your password and salt.
 
 ```bash
 hornet tool pwdhash


### PR DESCRIPTION
Changing all information about the way passwords are hashed or use in the config-files, to avoid confusion when creating hashes.

Added links to the tools-page at the necessary positions.